### PR TITLE
Updated delete method to be similar to batch operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,7 @@ And finally, you can also delete an existing record:
 
 ``` swift
 
-let record = Record(fields: [:], id: "YOUR_AIRTABLE_RECORD_ID")
-
-let publisher = airtable.delete(tableName: tableName, record: record)
+let publisher = airtable.delete(tableName: tableName, recordID: "YOUR_AIRTABLE_RECORD_ID")
 
 ```
 

--- a/Sources/AirtableKit/AirtableKit.swift
+++ b/Sources/AirtableKit/AirtableKit.swift
@@ -146,15 +146,10 @@ public final class Airtable {
     ///
     /// - Parameters:
     ///   - tableName: Name of the table where the record is
-    ///   - record: The record to delete.
+    ///   - recordID: The id of the record to delete.
     /// - Returns: A publisher with either the record which was deleted or an error
-    public func delete(tableName: String, record: Record) -> AnyPublisher<Record, AirtableError> {
-        guard let id = record.id else {
-            let error = AirtableError.missingRequiredFields("id")
-            return Fail<Record, AirtableError>(error: error).eraseToAnyPublisher()
-        }
-        
-        let request = buildRequest(method: "DELETE", path: "\(tableName)/\(id)")
+    public func delete(tableName: String, recordID: String) -> AnyPublisher<Record, AirtableError> {
+        let request = buildRequest(method: "DELETE", path: "\(tableName)/\(recordID)")
         return performRequest(request, decoder: responseDecoder.decodeDeleteResponse(data:))
     }
     

--- a/Tests/AirtableKitTests/DateFormatterTests.swift
+++ b/Tests/AirtableKitTests/DateFormatterTests.swift
@@ -15,7 +15,7 @@ class DateFormatterTests: QuickSpec {
             
             context("extracting a correctly-formated string date") {
                 let stringDate = "2017-10-16T11:37:26.000Z"
-                var testingDaste: Date!
+                var testingDate: Date!
                 beforeEach {
                     testingDate = formatter.date(from: stringDate)!
                 }


### PR DESCRIPTION
This PR closes #21 by updating the `delete` operation so that it can be used similarly to the batch operation.
