### PR TITLE
Update xcodeproj

### DIFF
--- a/Example/AirtableKitExample/AirtableKitExample.xcodeproj/project.pbxproj
+++ b/Example/AirtableKitExample/AirtableKitExample.xcodeproj/project.pbxproj
@@ -382,8 +382,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:appledeveloperacademypucrs/AirtableKit.git";
 			requirement = {
-				branch = feature/ExampleApp;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This PR closes #20 by changing `.xcodeproj` file of the example app to use the newly released version of AirtableKit.